### PR TITLE
 Remove extra newlines on clipboard copy

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -80,7 +80,7 @@ export default function App() {
 						value={result}
 						readOnly
 					></textarea>
-					<CopyToClipboard text={result} onCopy={() => toast.success('Copied!')}>
+					<CopyToClipboard text={result.trim()} onCopy={() => toast.success('Copied!')}>
 						<ClipboardCopyIcon className="w-6 h-6 mt-3 text-gray-500 cursor-pointer md:mr-1" />
 					</CopyToClipboard>
 				</div>
@@ -93,7 +93,7 @@ export default function App() {
 						value={resultJSS}
 						readOnly
 					></textarea>
-					<CopyToClipboard text={resultJSS} onCopy={() => toast.success('Copied!')}>
+					<CopyToClipboard text={resultJSS.trim()} onCopy={() => toast.success('Copied!')}>
 						<ClipboardCopyIcon className="w-6 h-6 mt-3 text-gray-500 cursor-pointer md:mr-1" />
 					</CopyToClipboard>
 				</div>


### PR DESCRIPTION
Trims whitespace from copied text to prevent multiple blank lines
[1.webm](https://github.com/user-attachments/assets/912c1913-8749-472c-a665-5de07ef1ce11)
